### PR TITLE
added labelWidth property

### DIFF
--- a/NavigationMenu/NavigationMenuView/SIMenuCell.h
+++ b/NavigationMenu/NavigationMenuView/SIMenuCell.h
@@ -10,4 +10,6 @@
 
 @interface SIMenuCell : UITableViewCell
 
+@property (nonatomic) CGFloat labelWidth;
+
 @end

--- a/NavigationMenu/NavigationMenuView/SIMenuCell.m
+++ b/NavigationMenu/NavigationMenuView/SIMenuCell.m
@@ -38,7 +38,7 @@
 {
     [super layoutSubviews];
     
-    self.textLabel.frame = CGRectMake((self.frame.size.width - [SIMenuConfiguration labelWidth]) / 2.0, self.textLabel.frame.origin.y, [SIMenuConfiguration labelWidth], self.textLabel.frame.size.height);
+    self.textLabel.frame = CGRectMake((self.frame.size.width - self.labelWidth) / 2.0, self.textLabel.frame.origin.y, self.labelWidth, self.textLabel.frame.size.height);
 }
 
 - (void)setSelected:(BOOL)selected

--- a/NavigationMenu/NavigationMenuView/SIMenuConfiguration.h
+++ b/NavigationMenu/NavigationMenuView/SIMenuConfiguration.h
@@ -13,9 +13,6 @@
 //Menu width
 + (float)menuWidth;
 
-//Label width
-+ (float)labelWidth;
-
 //Menu item height
 + (float)itemCellHeight;
 

--- a/NavigationMenu/NavigationMenuView/SIMenuConfiguration.m
+++ b/NavigationMenu/NavigationMenuView/SIMenuConfiguration.m
@@ -23,12 +23,6 @@
     return 34.0f;
 }
 
-//Label width
-+ (float)labelWidth
-{
-    return 230.0f;
-}
-
 //Animation duration of menu appearence
 + (float)animationDuration
 {

--- a/NavigationMenu/NavigationMenuView/SIMenuTable.h
+++ b/NavigationMenu/NavigationMenuView/SIMenuTable.h
@@ -26,6 +26,8 @@
 
 @property (nonatomic, strong) NSArray* items;
 
+@property (nonatomic) CGFloat labelWidth;
+
 - (id)initWithFrame:(CGRect)frame items:(NSArray *)items;
 - (void)show;
 - (void)hide;

--- a/NavigationMenu/NavigationMenuView/SIMenuTable.m
+++ b/NavigationMenu/NavigationMenuView/SIMenuTable.m
@@ -230,7 +230,7 @@
         UIView* view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.frame.size.width, 1)];
         [view setBackgroundColor:[UIColor colorWithWhite:1.0f alpha:1.0f]];
 
-        UIView* lineView = [[UIView alloc] initWithFrame:CGRectMake((self.frame.size.width - [SIMenuConfiguration labelWidth]) / 2.0, 0, [SIMenuConfiguration labelWidth], 1)];
+        UIView* lineView = [[UIView alloc] initWithFrame:CGRectMake((self.frame.size.width - self.labelWidth) / 2.0, 0, self.labelWidth, 1)];
         lineView.backgroundColor    = [UIColor colorWithHexString:@"a1a5a3"];
         lineView.alpha              = 0.8f;
         [view addSubview:lineView];
@@ -250,7 +250,7 @@
         [DNThemeManager customizeLabel:label withGroup:@"MV" andScreen:@"CategoryMenu" andItem:@"HeaderLabel"];
         [view addSubview:label];
 
-        UIView* lineView = [[UIView alloc] initWithFrame:CGRectMake((self.frame.size.width - [SIMenuConfiguration labelWidth]) / 2.0, 0, [SIMenuConfiguration labelWidth], 1)];
+        UIView* lineView = [[UIView alloc] initWithFrame:CGRectMake((self.frame.size.width - self.labelWidth) / 2.0, 0, self.labelWidth, 1)];
         lineView.backgroundColor    = [UIColor colorWithHexString:@"a1a5a3"];
         lineView.alpha              = 0.8f;
         [view addSubview:lineView];
@@ -272,11 +272,11 @@
     static NSString *cellIdentifier = @"Cell";
     
     SIMenuCell *cell = (SIMenuCell *)[tableView dequeueReusableCellWithIdentifier:cellIdentifier];
-    
     if (cell == nil) {
         cell = [[SIMenuCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier];
     }
     
+    cell.labelWidth = self.labelWidth;
     cell.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
     NSDictionary*   sectionD    = self.items[indexPath.section];

--- a/NavigationMenu/NavigationMenuView/SINavigationMenuView.m
+++ b/NavigationMenu/NavigationMenuView/SINavigationMenuView.m
@@ -26,7 +26,7 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.menuButton = [[SIMenuButton alloc] initWithFrame:frame];
+        self.menuButton = [[SIMenuButton alloc] initWithFrame:CGRectMake(0.0, 0.0, frame.size.width, frame.size.height)];
         self.menuButton.title.text = [title uppercaseString];
         [self.menuButton addTarget:self action:@selector(onHandleMenuTap:) forControlEvents:UIControlEventTouchUpInside];
         [self addSubview:self.menuButton];
@@ -109,6 +109,7 @@
         CGRect frame = mainWindow.frame;
         frame.origin.y += self.frame.size.height + [[UIApplication sharedApplication] statusBarFrame].size.height;
         self.table = [[SIMenuTable alloc] initWithFrame:frame items:self.items];
+        self.table.labelWidth = self.frame.size.width;
         self.table.menuDelegate = self;
         self.table.currentIndexPath = self.initialIndexPath;
     }


### PR DESCRIPTION
previously this class was using a constant 230.0 pixels for label width. Updated to use a property instead that is set based on the width of the Menu Button's title label. This way the drop down menu items are the same width as the menu button title and will avoid the current transition from a long title being truncated when finished.

@ehlersd good to merge.
